### PR TITLE
Update default maxDistinctValues to 1000

### DIFF
--- a/whiteRRabbit.R
+++ b/whiteRRabbit.R
@@ -49,7 +49,7 @@ option_list <- list(
         help = "Maximum rows to read per file (-1 for all). If random_sample is TRUE, a random sample of maxRows is used [default: %default]", metavar = "N"
     ),
     make_option(c("-x", "--maxDistinctValues"),
-        type = "integer", default = 50,
+        type = "integer", default = 1000,
         help = "Maximum distinct values to display in Frequencies [default: %default]", metavar = "N"
     ),
     make_option(c("-p", "--prefix"),


### PR DESCRIPTION
## Summary
- adjust `--maxDistinctValues` default value to 1000 in `whiteRRabbit.R`
- documentation already used 1000 so no updates were required

## Testing
- `Rscript whiteRRabbit.R --help` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d51c9ef6c832785f5accec1af651c