### PR TITLE
Align license references with Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # whiteRRabbit
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Overview
 
@@ -141,7 +141,7 @@ This implementation of **whiteRRabbit** is inspired by the summary statistics ap
 
 ## 📄 License
 
-This project is licensed under the [GNU General Public License v3.0 (2025)](https://www.gnu.org/licenses/gpl-3.0.html).
+This project is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 ---
 

--- a/doc/whiteRRabbit.md
+++ b/doc/whiteRRabbit.md
@@ -123,7 +123,7 @@ For each input file:
 
 ## 📜 License
 
-This project is licensed under the [GNU General Public License v3.0 (2025)](https://www.gnu.org/licenses/gpl-3.0.html).
+This project is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 ---
 


### PR DESCRIPTION
## Summary
- update badge and license links in README
- fix license text in documentation

## Testing
- `Rscript whiteRRabbit.R --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d51ca69548327851f296a70903eb8